### PR TITLE
Abstract block uses protected variable  - checkout results in error

### DIFF
--- a/Block/Checkout/Config.php
+++ b/Block/Checkout/Config.php
@@ -23,6 +23,6 @@ class Config extends Template
      */
     public function getScriptUrl()
     {
-        return $this->scopeConfig->getValue('sendcloud/sendcloud/script_url', ScopeInterface::SCOPE_STORE);
+        return $this->_scopeConfig->getValue('sendcloud/sendcloud/script_url', ScopeInterface::SCOPE_STORE);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "magento2-module",
   "homepage": "https://www.sendcloud.com/",
   "license": "Apache-2.0",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "require": {
     "magento/framework": ">=100 <103"
   },

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="SendCloud_SendCloud" setup_version="1.0.14">
+    <module name="SendCloud_SendCloud" setup_version="1.0.15">
         <sequence>
             <module name="Magento_Shipping"/>
             <module name="Magento_Checkout" />


### PR DESCRIPTION
An error has been throwed when opening the checkout:

Notice: Undefined property: `SendCloud\SendCloud\Block\Checkout\Config::$scopeConfig in vendor/sendcloud/sendcloud/Block/Checkout/Config.php` on line 26

`Magento\Framework\View\Element\AbstractBlock` uses `$_scopeconfig` in stead of `$scopeconfig`. AbstractHelper uses `$scopeconfig`, this is ok.