### PR TITLE
Restored missing body from getAllowedMethods()

### DIFF
--- a/Model/Carrier/SendCloud.php
+++ b/Model/Carrier/SendCloud.php
@@ -122,6 +122,7 @@ class SendCloud extends AbstractCarrierOnline implements CarrierInterface
      */
     public function getAllowedMethods()
     {
+         return [$this->_code => $this->getConfigData('name')];
     }
 
     /**


### PR DESCRIPTION
Removed earlier in https://github.com/creative-ict/sendcloud/commit/34adf2f5b7a0d16ceabe00360a21512e746addd3

Fixes #34