### PR TITLE
Critical error: Compilation from source: LESS file is empty

### DIFF
--- a/Api/ModuleInformationInterface.php
+++ b/Api/ModuleInformationInterface.php
@@ -4,7 +4,6 @@ namespace SendCloud\SendCloud\Api;
 
 /**
  * Interface ModuleInformationInterface
- * @package SendCloud\SendCloud\Api
  */
 interface ModuleInformationInterface
 {

--- a/Api/ServicePointInterface.php
+++ b/Api/ServicePointInterface.php
@@ -4,7 +4,6 @@ namespace SendCloud\SendCloud\Api;
 
 /**
  * Interface ServicePointInterface
- * @package SendCloud\SendCloud\Api
  */
 interface ServicePointInterface
 {

--- a/Api/SettingsInterface.php
+++ b/Api/SettingsInterface.php
@@ -3,7 +3,6 @@ namespace SendCloud\SendCloud\Api;
 
 /**
  * Interface SettingsInterface
- * @package SendCloud\SendCloud\Api
  */
 interface SettingsInterface
 {

--- a/Block/Adminhtml/Carrier/Servicepointrate/Grid.php
+++ b/Block/Adminhtml/Carrier/Servicepointrate/Grid.php
@@ -131,7 +131,6 @@ class Grid extends Extended
         return parent::_prepareCollection();
     }
 
-
     /**
      * Prepare table columns
      *

--- a/Block/Adminhtml/Form/Field/Import.php
+++ b/Block/Adminhtml/Form/Field/Import.php
@@ -22,8 +22,8 @@ class Import extends AbstractElement
     {
         $html = '';
 
-        $html .= '<input id="time_condition_sendcloud" type="hidden" name="' . $this->getName() . '" value="' . time() . '" />';
-
+        $html .= '<input id="time_condition_sendcloud" type="hidden" name="'
+            . $this->getName() . '" value="' . time() . '" />';
         $html .= <<<EndHTML
         <script>
         require(['prototype'], function(){

--- a/Block/Checkout/Config.php
+++ b/Block/Checkout/Config.php
@@ -7,10 +7,10 @@ use Magento\Store\Model\ScopeInterface;
 
 /**
  * Class Config
- * @package SendCloud\SendCloud\Block\Checkout
  */
 class Config extends Template
 {
+
     /**
      * @return mixed
      */

--- a/Block/System/Config/Form/Button.php
+++ b/Block/System/Config/Form/Button.php
@@ -5,10 +5,10 @@ namespace SendCloud\SendCloud\Block\System\Config\Form;
 /**
  * Class Button
  *
- * @package SendCloud\SendCloud\Block\System\Config\Form
  */
 class Button extends \Magento\Config\Block\System\Config\Form\Field
 {
+
     const BUTTON_TEMPLATE = 'system/config/button/button.phtml';
 
     /**

--- a/Controller/Adminhtml/AutoConnect/AutoGenerateApiUser.php
+++ b/Controller/Adminhtml/AutoConnect/AutoGenerateApiUser.php
@@ -13,10 +13,10 @@ use Magento\Authorization\Model\UserContextInterface;
 /**
  * Class AutoGenerateApiUser
  *
- * @package SendCloud\SendCloud\Controller\Adminhtml\AutoConnect
  */
 class AutoGenerateApiUser
 {
+
     /** @var UserFactory  */
     private $userFactory;
 
@@ -36,7 +36,6 @@ class AutoGenerateApiUser
         'Magento_Sales::ship'
     ];
 
-
     /** @var RoleFactory  */
     private $roleFactory;
 
@@ -51,7 +50,12 @@ class AutoGenerateApiUser
      * @param RoleFactory $roleFactory
      * @param RulesFactory $rulesFactory
      */
-    public function __construct(UserFactory $userFactory, SendCloudLogger $logger, RoleFactory $roleFactory, RulesFactory $rulesFactory)
+    public function __construct(
+        UserFactory $userFactory,
+        SendCloudLogger $logger,
+        RoleFactory $roleFactory,
+        RulesFactory $rulesFactory
+    )
     {
         $this->userFactory = $userFactory;
         $this->logger = $logger;

--- a/Controller/Adminhtml/AutoConnect/Connector.php
+++ b/Controller/Adminhtml/AutoConnect/Connector.php
@@ -12,7 +12,6 @@ use SendCloud\SendCloud\Logger\SendCloudLogger;
 /**
  * Class Index
  *
- * @package SendCloud\SendCloud\Controller\Adminhtml\AutoConnect
  */
 class Connector extends Action
 {
@@ -37,7 +36,13 @@ class Connector extends Action
      * @param Random $mathRandom
      * @param SendCloudLogger $logger
      */
-    public function __construct(Context $context, PageFactory $resultPageFactory, AutoGenerateApiUser $autoGenerateApiUser, Random $mathRandom, SendCloudLogger $logger)
+    public function __construct(
+        Context $context,
+        PageFactory $resultPageFactory,
+        AutoGenerateApiUser $autoGenerateApiUser,
+        Random $mathRandom,
+        SendCloudLogger $logger
+    )
     {
         $this->resultPageFactory = $resultPageFactory;
         $this->autoGenerateApiUser = $autoGenerateApiUser;

--- a/Controller/Adminhtml/Exportrates/Exportrates.php
+++ b/Controller/Adminhtml/Exportrates/Exportrates.php
@@ -20,12 +20,10 @@ class Exportrates extends AbstractConfig
      */
     protected $_fileFactory;
 
-
     /**
      * @var StoreManagerInterface
      */
     protected $_storeManager;
-
 
     /**
      * Exportrates constructor.
@@ -46,7 +44,6 @@ class Exportrates extends AbstractConfig
         $this->_fileFactory = $fileFactory;
         parent::__construct($context, $configStructure, $sectionChecker);
     }
-
 
     /**
      * Export Servicepoint rates in csv format

--- a/Helper/Checkout.php
+++ b/Helper/Checkout.php
@@ -9,10 +9,10 @@ use SendCloud\SendCloud\Logger\SendCloudLogger;
 
 /**
  * Class Checkout
- * @package SendCloud\SendCloud\Helper
  */
 class Checkout extends AbstractHelper
 {
+
     private $sendCloudLogger;
 
     /**

--- a/Logger/SendCloudHandler.php
+++ b/Logger/SendCloudHandler.php
@@ -6,10 +6,10 @@ use Magento\Framework\Logger\Handler\Base;
 
 /**
  * Class SendCloudHandler
- * @package SendCloud\SendCloud\Logger
  */
 class SendCloudHandler extends Base
 {
+
     protected $loggerType = Logger::DEBUG;
     protected $fileName = '/var/log/sendcloud_exception.log';
 }

--- a/Model/Carrier/SendCloud.php
+++ b/Model/Carrier/SendCloud.php
@@ -31,10 +31,10 @@ use SendCloud\SendCloud\Model\ResourceModel\Carrier\ServicepointrateFactory;
 
 /**
  * Class SendCloud
- * @package SendCloud\SendCloud\Model\Carrier
  */
 class SendCloud extends AbstractCarrierOnline implements CarrierInterface
 {
+
     /**
      * @var string
      */
@@ -124,8 +124,7 @@ class SendCloud extends AbstractCarrierOnline implements CarrierInterface
         Checkout $helper,
         ServicepointrateFactory $servicepointrateFactory,
         array $data = []
-    )
-    {
+    ){
         $this->_rateResultFactory = $rateResultFactory;
         $this->_rateMethodFactory = $rateMethodFactory;
         $this->itemPriceCalculator = $itemPriceCalculator;
@@ -161,6 +160,7 @@ class SendCloud extends AbstractCarrierOnline implements CarrierInterface
      */
     protected function _doShipmentRequest(DataObject $request)
     {
+        //Do nothing at the moment
     }
 
     /**
@@ -193,7 +193,7 @@ class SendCloud extends AbstractCarrierOnline implements CarrierInterface
             $request->setSenConditionName($conditionName ? $conditionName : $this->_defaultConditionName);
         }
 
-        if($request->getSenConditionName() == $this->_defaultConditionName || !$request->getSenConditionName()) {
+        if ($request->getSenConditionName() == $this->_defaultConditionName || !$request->getSenConditionName()) {
 
             //default fixed behaviour
             $freeBoxes = $this->getFreeBoxesCount($request);
@@ -207,7 +207,8 @@ class SendCloud extends AbstractCarrierOnline implements CarrierInterface
             if ($shippingPrice !== false) {
                 $method = $this->createResultMethod($shippingPrice);
                 $amount = $this->getConfigData('price');
-                if ($this->getConfigData('free_shipping_enable') && $this->getConfigData('free_shipping_subtotal') <= $request->getBaseSubtotalInclTax()) {
+                if ($this->getConfigData('free_shipping_enable') &&
+                    $this->getConfigData('free_shipping_subtotal') <= $request->getBaseSubtotalInclTax()) {
                     $method->setPrice('0.00');
                     $method->setCost('0.00');
                 } else {
@@ -216,8 +217,7 @@ class SendCloud extends AbstractCarrierOnline implements CarrierInterface
                 }
                 $result->append($method);
             }
-        }
-        else {
+        } else {
 
             // exclude Virtual products price from Package value if pre-configured
             if (!$this->getConfigFlag('sen_include_virtual_price') && $request->getAllItems()) {
@@ -269,7 +269,7 @@ class SendCloud extends AbstractCarrierOnline implements CarrierInterface
                 $newPackageValue = $oldValue - $freePackageValue;
                 $request->setPackageValue($newPackageValue);
                 $request->setPackageValueWithDiscount($newPackageValue);
-                $request->setSenPackageValueWithDiscount($newPackageValue); //added so we set this according to the conditions we use in Sendcloud
+                $request->setSenPackageValueWithDiscount($newPackageValue);
             }
 
             $this->setFreeBoxes($freeBoxes);

--- a/Model/Config/Source/Servicepointrate.php
+++ b/Model/Config/Source/Servicepointrate.php
@@ -4,7 +4,6 @@ namespace SendCloud\SendCloud\Model\Config\Source;
 
 /**
  * Class Servicepointrate
- * @package SendCloud\SendCloud\Model\Config\Source
  *
  * TODO: class Servicepointrate implements \Magento\Framework\Option\OptionSourceInterface
  * use OptionSourceInterface as ArrayInterface is deprecated, but OptionSourceInterface gives compile error when used.
@@ -15,7 +14,6 @@ class Servicepointrate implements \Magento\Framework\Option\ArrayInterface
      * @var \SendCloud\SendCloud\Model\Carrier\SendCloud
      */
     protected $_carrierServicepointrate;
-
 
     /**
      * Servicepointrate constructor.

--- a/Observer/SaveServicePointsData.php
+++ b/Observer/SaveServicePointsData.php
@@ -8,7 +8,6 @@ use Magento\Quote\Model\QuoteRepository;
 
 /**
  * Class SaveServicePointsData
- * @package SendCloud\SendCloud\Observer
  */
 class SaveServicePointsData implements ObserverInterface
 {

--- a/Observer/SetOrderAttributes.php
+++ b/Observer/SetOrderAttributes.php
@@ -9,7 +9,6 @@ use Magento\Quote\Model\QuoteRepository;
 
 /**
  * Class SetOrderAttributes
- * @package SendCloud\SendCloud\Observer
  */
 class SetOrderAttributes implements ObserverInterface
 {

--- a/Plugin/BeforeSaveShippingInformation.php
+++ b/Plugin/BeforeSaveShippingInformation.php
@@ -12,7 +12,6 @@ use SendCloud\SendCloud\Logger\SendCloudLogger;
 
 /**
  * Class BeforeSaveShippingInformation
- * @package SendCloud\SendCloud\Plugin
  */
 class BeforeSaveShippingInformation
 {

--- a/Plugin/Order/OrderRepository.php
+++ b/Plugin/Order/OrderRepository.php
@@ -10,7 +10,6 @@ use Magento\Sales\Model\OrderRepository as MagentoOrderRepository;
 
 /**
  * Class OrderRepository
- * @package SendCloud\SendCloud\Plugin\Order
  */
 class OrderRepository
 {

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -9,7 +9,6 @@ use Magento\Framework\Setup\UpgradeSchemaInterface;
 
 /**
  * Class UpgradeSchema
- * @package SendCloud\SendCloud\Setup
  */
 class UpgradeSchema implements UpgradeSchemaInterface
 {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "magento2-module",
   "homepage": "https://www.sendcloud.com/",
   "license": "Apache-2.0",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "require": {
     "php": "~7.0|~7.1|~7.2|~7.3|~7.4"
   },

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="SendCloud_SendCloud" setup_version="1.6.0">
+    <module name="SendCloud_SendCloud" setup_version="1.6.1">
         <sequence>
             <module name="Magento_Shipping"/>
             <module name="Magento_Checkout" />

--- a/view/frontend/layout/amasty_checkout.xml
+++ b/view/frontend/layout/amasty_checkout.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-    <head>
-        <css src="SendCloud_SendCloud::css/servicepoint.css" />
-    </head>
-</page>

--- a/view/frontend/layout/sales_order_view.xml
+++ b/view/frontend/layout/sales_order_view.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-    <head>
-        <css src="SendCloud_SendCloud::css/servicepoint.css" />
-    </head>
     <body>
         <referenceBlock name="sales.order.print.info">
             <action method="setTemplate">


### PR DESCRIPTION
This PR removes frontend layout references to servicepoint.less file that was removed in https://github.com/creative-ict/sendcloud/pull/87/files

This avoids critical error: "Compilation from source: LESS file is empty .../SendCloud_SendCloud/css/servicepoint.less" from being thrown when a user surfs to `/sales/order/view/order_id/XXXX/`